### PR TITLE
Support for the Erlang's embedded mode.

### DIFF
--- a/src/nkservice_config.erl
+++ b/src/nkservice_config.erl
@@ -204,11 +204,13 @@ get_callback(Plugin) ->
     case code:ensure_loaded(Mod) of
         {module, _} ->
             {ok, Mod};
-        {error, nofile} ->
+        {error, Reason} when Reason =:= nofile; Reason =:= embedded ->
             case code:ensure_loaded(Plugin) of
                 {module, _} ->
                     {ok, Plugin};
                 {error, nofile} ->
+                    error;
+                {error, embedded} ->
                     error
             end
     end.


### PR DESCRIPTION
In the embedded mode, the function code:ensure_loaded/1 returns {error, embedded} instead of {error, nofile}.